### PR TITLE
Add missing architecture URL part to the installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,11 @@ see [RELEASING.md](RELEASING.md).
 A typical installation from the release binaries might look like the following:
 
 ```shell script
-export WASI_VERSION=20
+export WASI_ARCH=x86_64
+export WASI_VERSION=24
 export WASI_VERSION_FULL=${WASI_VERSION}.0
-wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
-tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
+wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
+tar xvf wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
 ```
 
 ## Use
@@ -143,7 +144,7 @@ tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
 Use the clang installed in the `wasi-sdk` directory:
 
 ```shell script
-export WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}
+export WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}-{WASI_ARCH}-linux
 CC="${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot"
 $CC foo.c -o foo.wasm
 ```


### PR DESCRIPTION
It seems like the release artifacts layout has been changed a bit, so installation and usage shell scripts need a little update